### PR TITLE
Avoid unnecessary casting of ints to floats in Willow output

### DIFF
--- a/forest/willow/log_stats.py
+++ b/forest/willow/log_stats.py
@@ -97,7 +97,6 @@ def comm_logs_summaries(ID:str, df_text, df_call, stamp_start, stamp_end, tz_str
                   num_uniq_mis_call, total_time_in_call, total_time_out_call, num_s, num_r, num_mms_s, num_mms_r, num_s_tel,
                   num_r_tel, total_char_s, total_char_r]
         summary_stats.append(newline)
-    summary_stats = np.array(summary_stats)
     if option == 'daily':
         stats_pdframe = pd.DataFrame(summary_stats, columns=['year', 'month', 'day','num_in_call', 'num_out_call', 'num_mis_call',
                 'num_in_caller', 'num_out_caller','num_mis_caller', 'total_mins_in_call', 'total_mins_out_call',

--- a/forest/willow/log_stats.py
+++ b/forest/willow/log_stats.py
@@ -101,14 +101,12 @@ def comm_logs_summaries(ID:str, df_text, df_call, stamp_start, stamp_end, tz_str
         stats_pdframe = pd.DataFrame(summary_stats, columns=['year', 'month', 'day','num_in_call', 'num_out_call', 'num_mis_call',
                 'num_in_caller', 'num_out_caller','num_mis_caller', 'total_mins_in_call', 'total_mins_out_call',
                 'num_s', 'num_r', 'num_mms_s', 'num_mms_r', 'num_s_tel','num_r_tel', 'total_char_s', 'total_char_r',
-                'text_reciprocity_incoming','text_reciprocity_outgoing'],
-                dtype=int)
+                'text_reciprocity_incoming','text_reciprocity_outgoing'])
     if option == 'hourly':
         stats_pdframe = pd.DataFrame(summary_stats, columns=['year', 'month', 'day','hour','num_in_call', 'num_out_call',
                 'num_mis_call','num_in_caller', 'num_out_caller','num_mis_caller', 'total_mins_in_call', 'total_mins_out_call',
-                'num_s', 'num_r', 'num_mms_s', 'num_mms_r', 'num_s_tel','num_r_tel', 'total_char_s', 'total_char_r'],
-                 dtype=int)
-    
+                'num_s', 'num_r', 'num_mms_s', 'num_mms_r', 'num_s_tel','num_r_tel', 'total_char_s', 'total_char_r'])
+
     return stats_pdframe
 
 # Main function/wrapper should take standard arguments with Beiwe names:


### PR DESCRIPTION
This should resolve this error: https://github.com/onnela-lab/beiwe-discussions/issues/21#issuecomment-965554967

Note that `total_mins_in_call` and `total_mins_out_call` are still floats. I've fixed that in the attribute mappings Google sheet.
