### PR TITLE
change overpass request to POST from GET

### DIFF
--- a/forest/jasmine/traj2stats.py
+++ b/forest/jasmine/traj2stats.py
@@ -148,8 +148,8 @@ def get_nearby_locations(traj: np.ndarray) -> Tuple[dict, dict, dict]:
 
     query += "\n);\nout geom qt;"
 
-    response = requests.get(OSM_OVERPASS_URL,
-                            params={"data": query}, timeout=60)
+    response = requests.post(OSM_OVERPASS_URL,
+                            data={"data": query}, timeout=60)
     response.raise_for_status()
 
     res = response.json()

--- a/forest/jasmine/traj2stats.py
+++ b/forest/jasmine/traj2stats.py
@@ -149,7 +149,7 @@ def get_nearby_locations(traj: np.ndarray) -> Tuple[dict, dict, dict]:
     query += "\n);\nout geom qt;"
 
     response = requests.post(OSM_OVERPASS_URL,
-                            data={"data": query}, timeout=60)
+                             data={"data": query}, timeout=60)
     response.raise_for_status()
 
     res = response.json()


### PR DESCRIPTION
I read that changing the request from POST to GET solves the issue for long queries.

See below:
https://github.com/BrunoSalerno/overpass-api-ruby/issues/6
https://josm.openstreetmap.de/ticket/15141

Closes #74 