### PR TITLE
Fixed bug in forest.poplar.legacy.common_funcs.read_data

### DIFF
--- a/forest/poplar/legacy/common_funcs.py
+++ b/forest/poplar/legacy/common_funcs.py
@@ -176,7 +176,7 @@ def read_data(beiwe_id: str, study_folder: str, datastream: str, tz_str: str,
             directory_filenames, directory_filestamps = get_files_timestamps(
                 os.path.join(study_folder, beiwe_id, i)
             )
-            all_timestamps = all_timestamps + directory_filestamps.tolist()
+            all_timestamps += directory_filestamps.tolist()
         ordered_timestamps = sorted(all_timestamps)
         stamp_end1 = ordered_timestamps[-1]
         if time_end is None:

--- a/forest/poplar/legacy/common_funcs.py
+++ b/forest/poplar/legacy/common_funcs.py
@@ -173,10 +173,10 @@ def read_data(beiwe_id: str, study_folder: str, datastream: str, tz_str: str,
         all_timestamps: list = []
 
         for i in directories:
-            d_filenames, d_filestamps = get_files_timestamps(
+            directory_filenames, directory_filestamps = get_files_timestamps(
                 os.path.join(study_folder, beiwe_id, i)
             )
-            all_timestamps = all_timestamps + d_filestamps.tolist()
+            all_timestamps = all_timestamps + directory_filestamps.tolist()
         ordered_timestamps = sorted(all_timestamps)
         stamp_end1 = ordered_timestamps[-1]
         if time_end is None:

--- a/forest/poplar/legacy/common_funcs.py
+++ b/forest/poplar/legacy/common_funcs.py
@@ -173,10 +173,10 @@ def read_data(beiwe_id: str, study_folder: str, datastream: str, tz_str: str,
         all_timestamps: list = []
 
         for i in directories:
-            filenames, filestamps = get_files_timestamps(
+            d_filenames, d_filestamps = get_files_timestamps(
                 os.path.join(study_folder, beiwe_id, i)
             )
-            all_timestamps = all_timestamps + filestamps.tolist()
+            all_timestamps = all_timestamps + d_filestamps.tolist()
         ordered_timestamps = sorted(all_timestamps)
         stamp_end1 = ordered_timestamps[-1]
         if time_end is None:


### PR DESCRIPTION
I inadvertently introduced a bug in [this PR](https://github.com/onnela-lab/forest/commit/0d2fd710fa0ac8dc0aff6234680eb6b253d9799b) by naming two variables the same that should have been distinct. I discovered this when running forest on a study, and in this PR, I change these names so they are distinct again. Sorry for the confusion.

Some context about the bug: when running either log_stats_main or gps_stats_main, there would be a call to pd.read_csv regarding a file that didn't exist. This was because the function was iterating over all file names in all sub-directories for a user, and not just over file names in the sub-directory corresponding to the file type that the function was intending to read in.

The bug happens more frequently in log_stats_main because not all hours have communication data. 