### PR TITLE
add question index columns to survey answers lines

### DIFF
--- a/forest/sycamore/common.py
+++ b/forest/sycamore/common.py
@@ -567,6 +567,9 @@ def append_from_answers(
         for survey_id in agg_data["survey id"].unique():
             missing_data = find_missing_data(user, survey_id, agg_data,
                                              answers_data)
+            missing_data["survey id"] = missing_data["survey id"] + np.max(
+                agg_data["survey id"]
+            ) + 1
             missing_submission_data.append(missing_data)
 
     return pd.concat([agg_data] + missing_submission_data

--- a/forest/sycamore/common.py
+++ b/forest/sycamore/common.py
@@ -569,8 +569,8 @@ def append_from_answers(
                                              answers_data)
             if missing_data.shape[0] == 0:
                 continue
-            missing_data["question index"] += np.max(
-                agg_data["question index"]) + 1
+            missing_data["question index"] += \
+                np.max(agg_data["question index"]) + 1
             missing_submission_data.append(missing_data)
     return pd.concat([agg_data] + missing_submission_data
                      ).sort_values("UTC time")

--- a/forest/sycamore/common.py
+++ b/forest/sycamore/common.py
@@ -567,11 +567,12 @@ def append_from_answers(
         for survey_id in agg_data["survey id"].unique():
             missing_data = find_missing_data(user, survey_id, agg_data,
                                              answers_data)
-            missing_data["survey id"] = missing_data["survey id"] + np.max(
-                agg_data["survey id"]
-            ) + 1
+            if missing_data.shape[0] == 0:
+                continue
+            missing_data["question index"] = missing_data[
+                                                 "question index"
+            ] + np.max(agg_data["question index"]) + 1
             missing_submission_data.append(missing_data)
-
     return pd.concat([agg_data] + missing_submission_data
                      ).sort_values("UTC time")
 
@@ -875,7 +876,7 @@ def fix_radio_answer_choices(
     """
     Change the "question answer options" column into a list of question answer
         options. Also, correct for the fact that a semicolon may be a delimiter
-        between choices, an actual semicolon in a question, or a sanatized ","
+        between choices, an actual semicolon in a question, or a sanitized ","
 
     Args:
         aggregated_data:
@@ -945,7 +946,7 @@ def fix_radio_answer_choices(
             if isinstance(answer, str) and answer.find(";") != -1:
                 fixed_answer = answer.replace(";", ", ")
                 # replace semicolons with commas within the answer. We include
-                # a space after becaus we removed spaces after semicolons
+                # a space after because we removed spaces after semicolons
                 # earlier.
                 fixed_answer_choices = fixed_answer_choices.replace(
                     answer, fixed_answer

--- a/forest/sycamore/common.py
+++ b/forest/sycamore/common.py
@@ -569,9 +569,8 @@ def append_from_answers(
                                              answers_data)
             if missing_data.shape[0] == 0:
                 continue
-            missing_data["question index"] = missing_data[
-                                                 "question index"
-            ] + np.max(agg_data["question index"]) + 1
+            missing_data["question index"] += np.max(
+                agg_data["question index"]) + 1
             missing_submission_data.append(missing_data)
     return pd.concat([agg_data] + missing_submission_data
                      ).sort_values("UTC time")

--- a/forest/sycamore/common.py
+++ b/forest/sycamore/common.py
@@ -730,6 +730,15 @@ def read_user_answers_stream(
                 "UTC time"
             ].dt.tz_localize("UTC").dt.tz_convert(tz_str).dt.tz_localize(None)
 
+            # Add question index column to make things look like the survey
+            # timings stream. We do not need to worry about verifying that the
+            # question IDs on the new lines are different as we did for survey
+            # timings because these are all final submissions.
+            survey_data["question index"] = 1
+            survey_data["question index"] = survey_data.groupby(
+                ["survey id", "beiwe_id"]
+            )["question index"].cumsum()
+
             all_surveys.append(survey_data)
         if len(all_surveys) == 0:
             return pd.DataFrame(columns=["Local time"], dtype="datetime64[ns]")

--- a/forest/sycamore/tests/test_functions.py
+++ b/forest/sycamore/tests/test_functions.py
@@ -170,7 +170,7 @@ def test_agg_changed_answers_summary(agg_data_config):
     ca_detail, ca_summary = agg_changed_answers_summary(
         SURVEY_SETTINGS_PATH, agg_data_config
     )
-    assert ca_detail.shape[0] == 8
+    assert ca_detail.shape[0] == 11
     assert ca_detail.shape[1] == 14
     assert ca_summary.shape[0] == 7
     assert ca_summary.shape[1] == 9
@@ -182,7 +182,7 @@ def test_agg_changed_answers_summary_no_config(agg_data_no_config):
     ca_detail, ca_summary = agg_changed_answers_summary(
         SURVEY_SETTINGS_PATH, agg_data_no_config
     )
-    assert ca_detail.shape[0] == 8
+    assert ca_detail.shape[0] == 11
     assert ca_detail.shape[1] == 14
     assert ca_summary.shape[0] == 7
     assert ca_summary.shape[1] == 9
@@ -216,7 +216,7 @@ def test_read_user_answers_stream():
 def test_read_aggregate_answers_stream():
     df = read_aggregate_answers_stream(SAMPLE_DIR)
     assert len(df["beiwe_id"].unique()) == 2
-    assert df.shape[1] == 12
+    assert df.shape[1] == 13
 
 
 def test_format_responses_by_submission_adnc(agg_data_no_config):

--- a/forest/sycamore/tests/test_functions.py
+++ b/forest/sycamore/tests/test_functions.py
@@ -170,7 +170,7 @@ def test_agg_changed_answers_summary(agg_data_config):
     ca_detail, ca_summary = agg_changed_answers_summary(
         SURVEY_SETTINGS_PATH, agg_data_config
     )
-    assert ca_detail.shape[0] == 11
+    assert ca_detail.shape[0] == 12
     assert ca_detail.shape[1] == 14
     assert ca_summary.shape[0] == 7
     assert ca_summary.shape[1] == 9
@@ -182,7 +182,7 @@ def test_agg_changed_answers_summary_no_config(agg_data_no_config):
     ca_detail, ca_summary = agg_changed_answers_summary(
         SURVEY_SETTINGS_PATH, agg_data_no_config
     )
-    assert ca_detail.shape[0] == 11
+    assert ca_detail.shape[0] == 12
     assert ca_detail.shape[1] == 14
     assert ca_summary.shape[0] == 7
     assert ca_summary.shape[1] == 9


### PR DESCRIPTION
This fixes a bug that prevented answers from the `survey_answers` data stream from showing up in the outputs of `sycamore.responses.agg_changed_answers`