### PR TITLE
Fix sycamore submit line

### DIFF
--- a/forest/sycamore/common.py
+++ b/forest/sycamore/common.py
@@ -719,7 +719,10 @@ def read_user_answers_stream(
                 # questions
                 current_df["submit_line"] = 0
                 if not (current_df["answer"] == "NOT_PRESENTED").any():
-                    current_df.loc[current_df.shape[0] - 1, "submit_line"] = 1
+                    current_df = pd.concat(
+                        [current_df, pd.DataFrame({"submit_line": [1],
+                                                   "answer": ""})]
+                    ).reset_index()
 
                 current_df["surv_inst_flg"] = i
                 survey_dfs.append(current_df)

--- a/forest/sycamore/common.py
+++ b/forest/sycamore/common.py
@@ -719,10 +719,10 @@ def read_user_answers_stream(
                 # questions
                 current_df["submit_line"] = 0
                 if not (current_df["answer"] == "NOT_PRESENTED").any():
-                    current_df = pd.concat(
-                        [current_df, pd.DataFrame({"submit_line": [1],
-                                                   "answer": ""})]
-                    ).reset_index()
+                    current_df = pd.concat([
+                        current_df,
+                        pd.DataFrame({"submit_line": [1], "answer": ""})
+                    ]).reset_index()
 
                 current_df["surv_inst_flg"] = i
                 survey_dfs.append(current_df)

--- a/forest/sycamore/tests/test_functions.py
+++ b/forest/sycamore/tests/test_functions.py
@@ -210,13 +210,13 @@ def test_survey_submits_no_config_adnc(agg_data_no_config):
 
 def test_read_user_answers_stream():
     df = read_user_answers_stream(SAMPLE_DIR, "idr8gqdh", "UTC")
-    assert len(df["Local time"].unique()) == 2
+    assert len(df["Local time"].unique()) == 3
 
 
 def test_read_aggregate_answers_stream():
     df = read_aggregate_answers_stream(SAMPLE_DIR)
     assert len(df["beiwe_id"].unique()) == 2
-    assert df.shape[1] == 13
+    assert df.shape[1] == 14
 
 
 def test_format_responses_by_submission_adnc(agg_data_no_config):


### PR DESCRIPTION
This PR fixes a bug where the last response of every survey from the survey_answers stream had been deleted. 