### PR TITLE
Treat survey openings on Android and iOS the same

### DIFF
--- a/forest/sycamore/common.py
+++ b/forest/sycamore/common.py
@@ -208,8 +208,8 @@ def aggregate_surveys(
     all_data["question id"] = all_data.apply(
         lambda row:
         (all_data.loc[(all_data["survey id"] == row["survey id"]) &
-                       (all_data["question id"] != all_data["event"]),
-                       "question id"].tolist() + [""])[0]
+                      (all_data["question id"] != all_data["event"]),
+                      "question id"].tolist() + [""])[0]
         if row["question id"] == row["event"]
         else row["question id"],
         axis=1

--- a/forest/sycamore/common.py
+++ b/forest/sycamore/common.py
@@ -200,8 +200,17 @@ def aggregate_surveys(
         ] else row["event"],
         axis=1
     )
+    # Replace the question ID in these rows with a valid question ID for the
+    # survey so that survey scheduling metrics can incorporate surveys that
+    # were opened.
+    # If the only other rows in all_data were rows describing that the survey
+    # was first rendered, put "" for the question ID.
     all_data["question id"] = all_data.apply(
-        lambda row: np.nan if row["question id"] == row["event"]
+        lambda row:
+        (all_data.loc[(all_data["survey id"] == row["survey id"]) &
+                       (all_data["question id"] != all_data["event"]),
+                       "question id"].tolist() + [""])[0]
+        if row["question id"] == row["event"]
         else row["question id"],
         axis=1
     )
@@ -485,7 +494,10 @@ def aggregate_surveys_no_config(
         axis=1
     )
 
-    # Remove notification and expiration lines
+    # Remove lines where the event is 'notified' or 'expired'. These lines
+    # will show up on file collected from iOS devices, and they happen when a
+    # user gets notified of a survey and the survey expires because another
+    # survey gets sent.
     agg_data = agg_data.loc[(~agg_data["question id"].isnull())]
 
     # Convert to the study's timezone

--- a/forest/sycamore/tests/test_functions.py
+++ b/forest/sycamore/tests/test_functions.py
@@ -353,9 +353,10 @@ def test_get_choices_with_sep_values_both():
 def test_aggregate_surveys_config_using_sep_data():
     agg_data = aggregate_surveys_config(
         SEP_QS_DIR, CONFIG_WITH_SEPS, "UTC", history_path=HISTORY_WITH_SEPS)
-    assert agg_data.shape[0] == 19  # 4 lines (3 answers and a submit line) for
+    assert agg_data.shape[0] == 20  # 4 lines (3 answers and a submit line) for
     # each survey in survey_answers, plus 3 from the survey_timings file after
-    # the delivery line is removed
+    # the delivery line is removed. Plus, one line saying that the survey was
+    # opened and rendered for the user. 
     assert (agg_data["answer"] == "here (, ) is a comma").any()
     assert (agg_data["answer"] == ", comma at begin").any()
     assert (agg_data["answer"] == "comma at end , ").any()

--- a/forest/sycamore/tests/test_functions.py
+++ b/forest/sycamore/tests/test_functions.py
@@ -356,7 +356,7 @@ def test_aggregate_surveys_config_using_sep_data():
     assert agg_data.shape[0] == 20  # 4 lines (3 answers and a submit line) for
     # each survey in survey_answers, plus 3 from the survey_timings file after
     # the delivery line is removed. Plus, one line saying that the survey was
-    # opened and rendered for the user. 
+    # opened and rendered for the user.
     assert (agg_data["answer"] == "here (, ) is a comma").any()
     assert (agg_data["answer"] == ", comma at begin").any()
     assert (agg_data["answer"] == "comma at end , ").any()


### PR DESCRIPTION
Ensure that surveys that were opened on Android show up in the submits_and_summaries.csv output file