### PR TITLE
change NO_ANSWER_SELECTED to np.nan

### DIFF
--- a/forest/sycamore/common.py
+++ b/forest/sycamore/common.py
@@ -449,6 +449,12 @@ def aggregate_surveys_config(
         df_merged = pd.concat(
             [df_merged, audio_surveys], axis=0, ignore_index=False
         )
+    # mark NO_ANSWER_SELECTED as na because researchers will treat these the
+    # same, and researchers get confused if they see this as a possible answer
+    # that is distinct from na
+    df_merged.loc[
+        df_merged["answer"] == "NO_ANSWER_SELECTED", "answer"
+    ] = np.nan
 
     return df_merged.reset_index(drop=True)
 


### PR DESCRIPTION
I had a discussion with a researcher where they asked why some users answered NO_ANSWER_SELECTED to questions. I clarified that this happens when people don't mark anything for a question, and that they should just treat NO_ANSWER_SELECTED answers as NAs. However, I think that researchers using sycamore-processed data would prefer to just have the answers show up as NAs in the first place.