### PR TITLE
Get distance from ORS API when available

### DIFF
--- a/forest/bonsai/simulate_gps_data.py
+++ b/forest/bonsai/simulate_gps_data.py
@@ -115,6 +115,7 @@ def get_path(start: Tuple[float, float], end: Tuple[float, float],
             openrouteservice.exceptions.Timeout) as e:
         raise RuntimeError(e.message)
     coordinates = routes["features"][0]["geometry"]["coordinates"]
+    distance = routes["features"][0]["properties"]["summary"]["distance"]
     path_coordinates = [[coord[1], coord[0]] for coord in coordinates]
 
     # sometimes if exact coordinates of location are not in a road

--- a/forest/bonsai/tests/test_simulate_gps_data.py
+++ b/forest/bonsai/tests/test_simulate_gps_data.py
@@ -272,9 +272,8 @@ def test_get_path_ending_longitude(coords1, coords2, directions1, mocker):
 def test_get_path_distance(coords1, coords2, directions1, mocker):
     mocker.patch("openrouteservice.Client.directions",
                  return_value=directions1)
-    assert (round(get_path(coords1, coords2, Vehicle.CAR, "mock_api_key")[1],
-                  2)
-            == 843.05)
+    assert (get_path(coords1, coords2, Vehicle.CAR, "mock_api_key")[1]
+            == 1687.9)
 
 
 def test_get_path_close_locations(coords1, coords3):


### PR DESCRIPTION
Change in `get_path` function:
> Get distance between two sets of coordinates from OpenRouteService returns instead of great_circle_dist function.