### PR TITLE
jasmine osm summary statistic

### DIFF
--- a/forest/jasmine/traj2stats.py
+++ b/forest/jasmine/traj2stats.py
@@ -465,11 +465,12 @@ def gps_summaries(
                         )
                     else:
                         pause_array[
-                            great_circle_dist(
-                                row[1], row[2],
-                                pause_array[:, 0], pause_array[:, 1],
-                            )
-                            <= 2*place_point_radius,
+                            np.argmin(
+                                great_circle_dist(
+                                    row[1], row[2],
+                                    pause_array[:, 0], pause_array[:, 1],
+                                )
+                            ),
                             -1,
                         ] += (row[6] - row[3]) / 60
 


### PR DESCRIPTION
Fixed bug in implementation, where if our location of interest was in the middle of other locations that weren't close enough to each other, time spent would be added to all of them and not the closest one.

This links to issue 114 in `beiwe-discussions`