### PR TITLE
Bug in row calculation in data2mobmat

### DIFF
--- a/forest/jasmine/data2mobmat.py
+++ b/forest/jasmine/data2mobmat.py
@@ -990,8 +990,6 @@ def infer_mobmat(mobmat: np.ndarray, interval: float, r: float) -> np.ndarray:
     """
     sys.stdout.write("Infer unclassified windows ...\n")
 
-    n_rows = mobmat.shape[0]
-
     # Infer unknown status
     # The 'unknown' status (code 3)
     # is inferred based on neighbouring data points
@@ -1006,6 +1004,8 @@ def infer_mobmat(mobmat: np.ndarray, interval: float, r: float) -> np.ndarray:
 
     # check for missing intervals and correct them
     new_pauses_array, mobmat = correct_missing_intervals(mobmat)
+
+    n_rows = mobmat.shape[0]
 
     # connect flights and pauses
     for j in np.arange(1, n_rows):


### PR DESCRIPTION
Move location of `n_rows` calculation in `infer_mobmat`, since `mobmat` number of rows is changing.

Closes #177 