### PR TITLE
Remove deprecation warning for Sycamore

### DIFF
--- a/forest/sycamore/read_audio.py
+++ b/forest/sycamore/read_audio.py
@@ -136,7 +136,7 @@ def read_user_audio_recordings_stream(
             if valid_file:
                 all_files.append(filename)
                 all_durations.append(librosa.get_duration(
-                    path = os.path.join(audio_dir, survey, filename)
+                    path=os.path.join(audio_dir, survey, filename)
                 ))
 
         if len(all_files) == 0:

--- a/forest/sycamore/read_audio.py
+++ b/forest/sycamore/read_audio.py
@@ -136,7 +136,7 @@ def read_user_audio_recordings_stream(
             if valid_file:
                 all_files.append(filename)
                 all_durations.append(librosa.get_duration(
-                    filename=os.path.join(audio_dir, survey, filename)
+                    path = os.path.join(audio_dir, survey, filename)
                 ))
 
         if len(all_files) == 0:


### PR DESCRIPTION
This removes one of the warnings mentioned in https://github.com/onnela-lab/forest/issues/211