### PR TITLE
Address `FutureWarning`s in Sycamore

### DIFF
--- a/forest/sycamore/common.py
+++ b/forest/sycamore/common.py
@@ -414,9 +414,7 @@ def aggregate_surveys_config(
         config_surveys[["config_id", "question_id"]], how="left",
         left_on="question id", right_on="question_id"
     ).drop(["question_id"], axis=1)
-    df_merged["config_id_update"] = df_merged["config_id"].fillna(
-        method="ffill"
-    )
+    df_merged["config_id_update"] = df_merged["config_id"].ffill()
     df_merged["config_id"] = df_merged.apply(
         lambda row:
         row["config_id_update"] if row["event"] in ["User hit submit",

--- a/forest/sycamore/submits.py
+++ b/forest/sycamore/submits.py
@@ -525,7 +525,7 @@ def summarize_submits(submits_df: pd.DataFrame,
     if timeunit == Frequency.DAILY:
         submits["delivery_time_floor"] = submits["delivery_time"].dt.floor("D")
     elif timeunit == Frequency.HOURLY:
-        submits["delivery_time_floor"] = submits["delivery_time"].dt.floor("H")
+        submits["delivery_time_floor"] = submits["delivery_time"].dt.floor("h")
     if timeunit is not None:
         # round to the nearest desired unit
         submits["year"] = submits["delivery_time_floor"].dt.year


### PR DESCRIPTION
```
  /home/runner/work/forest/forest/forest/sycamore/common.py:417: FutureWarning: Series.fillna with 'method' is deprecated and will raise in a future version. Use obj.ffill() or obj.bfill() instead.
    df_merged["config_id_update"] = df_merged["config_id"].fillna(

forest/sycamore/tests/test_functions.py::test_summarize_submits_hour
  /home/runner/work/forest/forest/forest/sycamore/submits.py:528: FutureWarning: 'H' is deprecated and will be removed in a future version, please use 'h' instead.
    submits["delivery_time_floor"] = submits["delivery_time"].dt.floor("H")
```