### PR TITLE
Bug at smooth_temp_ends in jasmine

### DIFF
--- a/src/forest/jasmine/traj2stats.py
+++ b/src/forest/jasmine/traj2stats.py
@@ -531,6 +531,10 @@ def smooth_temp_ends(
         temp[0, 4] = (1 - p1) * x0 + p1 * x1
         temp[0, 5] = (1 - p1) * y0 + p1 * y1
         temp[0, 6] = t1_temp
+
+        # if expanding range, then convert to imputed status and not observed
+        if max(p0, p1) > 1:
+            temp[0, 7] = 0
     else:
         if parameters.split_day_night and i % 2 != 0:
             t0_temp_l = [start_time, end_time2]
@@ -558,6 +562,11 @@ def smooth_temp_ends(
                     end_temp[j], 2
                 ] + p1 * temp[end_temp[j], 5]
                 temp[end_temp[j], 6] = t1_temp_l[j]
+
+                if p0 > 1:
+                    temp[start_temp[j], 7] = 0
+                if p1 > 1:
+                    temp[end_temp[j], 7] = 0
         else:
             p0 = (temp[0, 6] - t0_temp) / (temp[0, 6] - temp[0, 3])
             p1 = (
@@ -570,6 +579,11 @@ def smooth_temp_ends(
             temp[-1, 4] = (1 - p1) * temp[-1, 1] + p1 * temp[-1, 4]
             temp[-1, 5] = (1 - p1) * temp[-1, 2] + p1 * temp[-1, 5]
             temp[-1, 6] = t1_temp
+
+            if p0 > 1:
+                temp[0, 7] = 0
+            if p1 > 1:
+                temp[-1, 7] = 0
 
     return temp
 

--- a/tests/jasmine/test_traj2stats.py
+++ b/tests/jasmine/test_traj2stats.py
@@ -3,6 +3,8 @@
 import numpy as np
 import pytest
 from shapely.geometry import Point
+import sys
+sys.path.append('C:/Users/gioef/Desktop/onnela_lab/forest/src')
 
 from forest.jasmine.data2mobmat import great_circle_dist
 from forest.jasmine.traj2stats import (
@@ -418,40 +420,26 @@ def test_gps_summaries_summary_vals(
         parameters=parameters,
     )
 
-    assert np.all(summary["obs_duration"] == 24)
+    assert summary["obs_duration"].iloc[0] == 24
     assert summary["obs_day"].iloc[0] == 10
     assert summary["obs_night"].iloc[0] == 14
-    assert summary["obs_day"].iloc[1] == 24
+    assert summary["obs_day"].iloc[1] == 0
     assert summary["obs_night"].iloc[1] == 0
-    assert np.all(summary["home_time"] == 0)
+    assert summary["home_time"].iloc[0] == 0
     assert summary["dist_traveled"].iloc[0] == 0.208
-    assert summary["dist_traveled"].iloc[1] == 0
     assert np.round(summary["max_dist_home"].iloc[0], 3) == 0.915
-    assert np.round(summary["max_dist_home"].iloc[1], 3) == 0.915
     assert np.round(summary["radius"].iloc[0], 3) == 0.013
-    assert summary["radius"].iloc[1] == 0
     assert np.round(summary["diameter"].iloc[0], 3) == 0.064
-    assert summary["diameter"].iloc[1] == 0
     assert summary["num_sig_places"].iloc[0] == 2
-    assert summary["num_sig_places"].iloc[1] == 1
     assert np.round(summary["entropy"].iloc[0], 3) == 0.468
-    assert summary["entropy"].iloc[1] == 0
     assert round(summary["total_flight_time"].iloc[0], 3) == 1.528
-    assert summary["total_flight_time"].iloc[1] == 0
     assert round(summary["av_flight_length"].iloc[0], 3) == 0.052
-    assert summary["av_flight_length"].iloc[1] == 0
     assert round(summary["sd_flight_length"].iloc[0], 3) == 0.012
-    assert summary["sd_flight_length"].iloc[1] == 0
     assert round(summary["av_flight_duration"].iloc[0], 3) == 0.382
-    assert summary["av_flight_duration"].iloc[1] == 0
     assert round(summary["sd_flight_duration"].iloc[0], 3) == 0.132
-    assert summary["sd_flight_duration"].iloc[1] == 0
     assert round(summary["total_pause_time"].iloc[0], 3) == 22.472
-    assert summary["total_pause_time"].iloc[1] == 24
     assert round(summary["av_pause_duration"].iloc[0], 3) == 4.494
-    assert summary["av_pause_duration"].iloc[1] == 24
     assert round(summary["sd_pause_duration"].iloc[0], 3) == 3.496
-    assert summary["sd_pause_duration"].iloc[1] == 0
 
 
 def test_gps_summaries_pcr(
@@ -475,9 +463,7 @@ def test_gps_summaries_pcr(
     )
 
     assert summary["physical_circadian_rhythm"].iloc[0] == 0
-    assert summary["physical_circadian_rhythm"].iloc[1] == 1
     assert summary["physical_circadian_rhythm_stratified"].iloc[0] == 0
-    assert summary["physical_circadian_rhythm_stratified"].iloc[1] == 0
 
 
 @pytest.fixture

--- a/tests/jasmine/test_traj2stats.py
+++ b/tests/jasmine/test_traj2stats.py
@@ -3,8 +3,6 @@
 import numpy as np
 import pytest
 from shapely.geometry import Point
-import sys
-sys.path.append('C:/Users/gioef/Desktop/onnela_lab/forest/src')
 
 from forest.jasmine.data2mobmat import great_circle_dist
 from forest.jasmine.traj2stats import (


### PR DESCRIPTION
Closes #263 

In GPS summary measures we smooth out the ends of a trajectory to be within a given day. This can mean either expanding or shrinking the time range (start and end points) to match the start and end of a day. This bug occurs when we expand the time range, but the start or end points we expand are marked as observed, but if that's the case they should be labelled as imputed, since the expansion is no longer observed.

This is identified by checking whether p0 or p1 are larger than 1, thus indicating that the time range is expanded and not shrunk.