### PR TITLE
Fix Sycamore Pandas3 compatibility issues in survey parsing and submi…

### DIFF
--- a/src/forest/sycamore/common.py
+++ b/src/forest/sycamore/common.py
@@ -990,7 +990,9 @@ def fix_radio_answer_choices(
     # remove first and last bracket as well as any nan, then split it by ;
     aggregated_data["question answer options"] = aggregated_data[
         "question answer options"
-    ].astype("str").apply(lambda x: re.sub(r"^\[|\]$|^nan$", "", x).split(";"))
+    ].apply(lambda x: "" if pd.isna(x) else str(x)).apply(
+        lambda x: re.sub(r"^\[|\]$|^nan$", "", x).split(";")
+    )
 
     return aggregated_data
 

--- a/src/forest/sycamore/submits.py
+++ b/src/forest/sycamore/submits.py
@@ -348,7 +348,7 @@ def survey_submits(
     )["Local time"].transform("first")
     # get rid of answers that were blank responses
     only_real_answers = agg.loc[
-        ~agg.answer.isin(["", np.nan, None, "[]", "NO_ANSWER_SELECTED"]),
+        ~agg.answer.isin(["", np.nan, None, [], "[]", "NO_ANSWER_SELECTED"]),
         ["beiwe_id", "survey id", "surv_inst_flg", "question id"]]
     # Look for the number of unique questions where the answer was a real thing
     only_real_answers["num_questions_answered"] = only_real_answers.groupby(

--- a/src/forest/sycamore/submits.py
+++ b/src/forest/sycamore/submits.py
@@ -348,7 +348,7 @@ def survey_submits(
     )["Local time"].transform("first")
     # get rid of answers that were blank responses
     only_real_answers = agg.loc[
-        ~agg.answer.isin(["", np.nan, None, [], "[]", "NO_ANSWER_SELECTED"]),
+        ~agg.answer.isin(["", np.nan, None, "[]", "NO_ANSWER_SELECTED"]),
         ["beiwe_id", "survey id", "surv_inst_flg", "question id"]]
     # Look for the number of unique questions where the answer was a real thing
     only_real_answers["num_questions_answered"] = only_real_answers.groupby(

--- a/src/forest/sycamore/submits.py
+++ b/src/forest/sycamore/submits.py
@@ -241,7 +241,7 @@ def gen_survey_schedule(
             tbl["delivery_time"] = pd.to_datetime(tbl["delivery_time"])
             # add a delivery time a week in the future to capture the last
             # delivery
-            week_after_last = tbl.delivery_time.max() + pd.Timedelta(7, "d")
+            week_after_last = tbl.delivery_time.max() + pd.Timedelta(7, "D")
             tbl = pd.concat(
                 [tbl, pd.DataFrame({"delivery_time": [week_after_last]})],
                 axis=0


### PR DESCRIPTION
This PR fixes two pandas 3 compatibility issues in Sycamore survey processing that caused `compute_survey_stats(...)` to fail.

## Problem
Running `compute_survey_stats(...)` with `pandas==3.0.0` raised two errors:
1. `TypeError: expected string or bytes-like object, got 'float'`
2. `ValueError: The truth value of an empty array is ambiguous`

## Root Cause
- In `fix_radio_answer_choices`, `question answer options` could contain NaN/float values that reached `re.sub(...)`.
- In `survey_submits`, `agg.answer.isin([...])` included `[]`, which triggers ambiguous truth evaluation with pandas 3 string dtype behavior.

## Changes
- `src/forest/sycamore/common.py`
  - Made `"question answer options"` conversion NaN-safe before regex/splitting.
- `src/forest/sycamore/submits.py`
  - Removed `[]` from the `isin(...)` blank-answer filter list.
