### PR TITLE
Update GitHub Actions workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,13 +13,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ['ubuntu-24.04', 'windows-2022', 'macos-14']
+        os: ['ubuntu-24.04', 'windows-2025', 'macos-26']
         python-version: ['3.11', '3.12']
     steps:
       - name: Check out Forest code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Forest dependencies for Linux

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,9 +18,9 @@ jobs:
         working-directory: './docs'
     steps:
       - name: Check out Forest code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install documentation build dependencies


### PR DESCRIPTION
To address Node 20 deprecation: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

No update is available for setup-ffmpeg yet: https://github.com/federicocarboni/setup-ffmpeg/issues/32
Potential alternatives: https://github.com/marketplace?query=ffmpeg&type=actions
