### PR TITLE
[allow-zstd-compressed-input] makes the change required to allow .zst files to load

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
     "shapely",
     "ssqueezepy",
     "timezonefinder",
+    "zstandard",
 ]
 keywords = ["digital phenotyping", "smartphone", "statistics", "accelerometer", "GPS"]
 classifiers = [

--- a/src/forest/oak/base.py
+++ b/src/forest/oak/base.py
@@ -459,9 +459,9 @@ def preprocess_dates(
             - date_start: datetime of initial date of study
             - date_end: datetime of final date of study
     """
-    # transform all files in folder to datelike format
+    # transform all files in folder to datelike format, strip all file extensions.
     file_dates = [
-        file.replace(".csv", "").replace("+00_00", "") for file in file_list
+        file.replace("+00_00", "").split(".", 1)[0] for file in file_list
     ]
     # process dates
     dates = [datetime.strptime(file, fmt) for file in file_dates]


### PR DESCRIPTION
I tested Oak, Willow, Jasmine, and Sycamore on the Beiwe Backend.
Change is just a requirement and a tweak to date/time interpretation in Oak.