### PR TITLE
refactor(poplar): replace pytz with stdlib zoneinfo

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "pandas",
     "pyproj",
     "python-dateutil",
-    "pytz",
+    "tzdata",
     "ratelimit",
     "requests",
     "scipy",
@@ -79,7 +79,6 @@ dev = [
     "pytest-xdist",
     "twine",
     "types-python-dateutil",
-    "types-pytz",
     "types-requests",
     "types-setuptools",
 ]

--- a/src/forest/poplar/constants/time.py
+++ b/src/forest/poplar/constants/time.py
@@ -1,6 +1,6 @@
 """Constants for working with Beiwe time formats.
 """
-from pytz import timezone
+from zoneinfo import ZoneInfo
 
 # seconds
 MIN_S = 60
@@ -51,4 +51,4 @@ AWARE_DATETIME_FORMAT = " ".join([DATE_FORMAT, TIME_FORMAT, TIMEZONE_FORMAT])
 OFFSET_DATETIME_FORMAT = " ".join([DATE_FORMAT, TIME_FORMAT, OFFSET_FORMAT])
 
 # commonly used time zones
-UTC = timezone("UTC")
+UTC = ZoneInfo("UTC")

--- a/src/forest/poplar/functions/time.py
+++ b/src/forest/poplar/functions/time.py
@@ -3,7 +3,7 @@ from logging import getLogger
 import datetime
 from typing import Union
 
-import pytz
+from zoneinfo import ZoneInfo
 
 from ..constants.time import (
     DATE_FORMAT, NAIVE_DATETIME_FORMAT, DAY_S, MIN_MS, UTC
@@ -46,7 +46,7 @@ def convert_seconds(second_of_day: int) -> Union[str, None]:
 
 
 def reformat_datetime(datetime_string: str, from_format: str, to_format: str,
-                      from_tz: Union[str, pytz.BaseTzInfo, None] = None
+                      from_tz: Union[str, datetime.tzinfo, None] = None
                       ) -> Union[str, None]:
     """Change the format of a datetime string.
 
@@ -55,7 +55,7 @@ def reformat_datetime(datetime_string: str, from_format: str, to_format: str,
         from_format (str): The format of time, expressed using directives
             from the datetime package.
         to_format (str): Convert to this time format.
-        from_tz (timezone from pytz.tzfile): Optionally, localize time
+        from_tz (datetime.tzinfo): Optionally, localize time
             before reformatting.
 
     Returns:
@@ -66,7 +66,7 @@ def reformat_datetime(datetime_string: str, from_format: str, to_format: str,
             datetime_string, from_format
         )
         if from_tz is not None and not isinstance(from_tz, str):
-            datetime_date = from_tz.localize(datetime_date)
+            datetime_date = datetime_date.replace(tzinfo=from_tz)
         reformat = datetime_date.strftime(to_format)
         return reformat
     except ValueError:
@@ -78,7 +78,7 @@ def reformat_datetime(datetime_string: str, from_format: str, to_format: str,
 
 def to_timestamp(
     datetime_string: str, from_format: str,
-    from_tz: Union[str, pytz.BaseTzInfo] = UTC
+    from_tz: Union[str, datetime.tzinfo] = UTC
 ) -> Union[int, None]:
     """Convert a datetime string to a timestamp.
 
@@ -86,7 +86,7 @@ def to_timestamp(
         datetime_string (str):  A human-readable datetime string.
         from_format (str):  The format of time, expressed using directives
             from the datetime package.
-        from_tz (timezone from pytz.tzfile):  The timezone of time.
+        from_tz (datetime.tzinfo):  The timezone of time.
 
     Returns:
         timestamp (int): Timestamp in milliseconds.
@@ -96,7 +96,7 @@ def to_timestamp(
             datetime_string, from_format
         )
         if not isinstance(from_tz, str):
-            utc_dt = from_tz.localize(datetime_date)
+            utc_dt = datetime_date.replace(tzinfo=from_tz)
             timestamp = round(utc_dt.timestamp() * 1000)
             return timestamp
         return None
@@ -108,7 +108,7 @@ def to_timestamp(
 
 
 def to_readable(timestamp: int, to_format: str,
-                to_tz: Union[str, pytz.BaseTzInfo] = UTC) -> Union[str, None]:
+                to_tz: Union[str, datetime.tzinfo] = UTC) -> Union[str, None]:
     """Convert a timestamp to a human-readable string localized to a
     particular timezone.
 
@@ -116,15 +116,17 @@ def to_readable(timestamp: int, to_format: str,
         timestamp (int): Timestamp in milliseconds.
         to_format (str): The format of readable, expressed using directives
             from the datetime package.
-        to_tz (str or timezone from pytz.tzfile):  The timezone of readable.
+        to_tz (str or datetime.tzinfo):  The timezone of readable.
 
     Returns:
         readable (str):  A human-readable datetime string.
     """
     try:
         if isinstance(to_tz, str):
-            to_tz = pytz.timezone(to_tz)
-        utc_dt = datetime.datetime.fromtimestamp(timestamp / 1000, tz=pytz.UTC)
+            to_tz = ZoneInfo(to_tz)
+        utc_dt = datetime.datetime.fromtimestamp(
+            timestamp / 1000, tz=datetime.timezone.utc
+        )
         local_dt = utc_dt.astimezone(to_tz)
         readable = local_dt.strftime(to_format)
         return readable

--- a/src/forest/poplar/functions/timezone.py
+++ b/src/forest/poplar/functions/timezone.py
@@ -3,7 +3,7 @@ from logging import getLogger
 import datetime
 from typing import Union, Optional
 
-import pytz
+from zoneinfo import ZoneInfo
 from timezonefinder import TimezoneFinder
 
 from ..constants.time import HOUR_S
@@ -21,7 +21,7 @@ def get_timezone(
         latitude, longitude (float): Coordinates.
 
     Returns:
-        timezone (str): Timezone string that can be read by pytz.timezone().
+        timezone (str): Timezone string that can be read by zoneinfo.ZoneInfo.
     """
     tf_obj = TimezoneFinder()
     timezone = tf_obj.timezone_at(lng=longitude, lat=latitude)
@@ -29,20 +29,20 @@ def get_timezone(
 
 
 def get_offset(
-    timestamp: int, timezone: Union[str, pytz.BaseTzInfo]
+    timestamp: int, timezone: Union[str, datetime.tzinfo]
 ) -> Optional[float]:
     """Get UTC offset, given timestamp and timezone.
 
     Args:
         timestamp (int):  Millisecond timestamp.
-        timezone (str or timezone from pytz.tzfile): Timezone for which to
+        timezone (str or datetime.tzinfo): Timezone for which to
             calculate UTC offset.
 
     Returns:
         offset (float):  UTC offset in hours.
     """
     if isinstance(timezone, str):
-        timezone = pytz.timezone(timezone)
+        timezone = ZoneInfo(timezone)
     datetime_date = datetime.datetime.fromtimestamp(timestamp / 1000, timezone)
     offset_utc = datetime_date.utcoffset()
     if offset_utc is None:

--- a/src/forest/poplar/legacy/common_funcs.py
+++ b/src/forest/poplar/legacy/common_funcs.py
@@ -7,7 +7,7 @@ from typing import Any, Union
 
 import numpy as np
 import pandas as pd
-from pytz import timezone
+from zoneinfo import ZoneInfo
 
 logger = logging.getLogger(__name__)
 
@@ -21,17 +21,17 @@ def datetime2stamp(time_list: Union[list, tuple], tz_str: str) -> int:
         tz_str: str,
             timezone where the study is conducted
             please use
-            # from pytz import all_timezones
-            # all_timezones
+            # import zoneinfo
+            # zoneinfo.available_timezones()
             to check all timezones
 
     Returns:
         Unix time, which is what Beiwe uses
     """
-    loc_tz = timezone(tz_str)
-    loc_dt = loc_tz.localize(datetime(*time_list))
+    loc_tz = ZoneInfo(tz_str)
+    loc_dt = datetime(*time_list).replace(tzinfo=loc_tz)
 
-    utc = timezone("UTC")
+    utc = ZoneInfo("UTC")
     utc_dt = loc_dt.astimezone(utc)
 
     timestamp = calendar.timegm(utc_dt.timetuple())
@@ -47,16 +47,16 @@ def stamp2datetime(stamp: Union[float, int], tz_str: str) -> list:
         tz_str: str,
             timezone where the study is conducted
             please use
-            # from pytz import all_timezones
-            # all_timezones
+            # import zoneinfo
+            # zoneinfo.available_timezones()
             to check all timezones
 
     Returns:
         a list of integers [year, month, day, hour (0-23), min, sec] in the
          specified tz
     """
-    loc_tz = timezone(tz_str)
-    utc_dt = datetime.fromtimestamp(stamp, timezone("UTC"))
+    loc_tz = ZoneInfo(tz_str)
+    utc_dt = datetime.fromtimestamp(stamp, ZoneInfo("UTC"))
     loc_dt = utc_dt.astimezone(loc_tz)
     return [
         loc_dt.year, loc_dt.month, loc_dt.day,

--- a/src/forest/sycamore/common.py
+++ b/src/forest/sycamore/common.py
@@ -329,7 +329,7 @@ def convert_timezone_df(df_merged: pd.DataFrame, tz_str: str = "UTC",
         df_merged(DataFrame):
             Dataframe that has a field of dates that are in UTC time
         tz_str(str):
-            Study timezone (this should be a string from the pytz library)
+            Study timezone (this should be a string in the IANA tz database)
         utc_col:
             Name of column in data that has UTC time dates
 

--- a/tests/poplar/test_poplar_functions.py
+++ b/tests/poplar/test_poplar_functions.py
@@ -1,4 +1,6 @@
+import datetime
 import os
+from zoneinfo import ZoneInfo
 
 import numpy as np
 import pandas as pd
@@ -6,6 +8,8 @@ import pytest
 from tempfile import TemporaryDirectory
 
 from forest.utils import get_ids
+from forest.poplar.functions.time import to_timestamp, to_readable
+from forest.poplar.functions.timezone import get_offset
 
 from forest.poplar.functions.helpers import (
     clean_dataframe, get_windows, directory_size, sort_by, join_lists,
@@ -203,3 +207,57 @@ def test_sample_var(gps_df):
 def test_get_ids():
     users_list = get_ids(TEST_DATA_DIR)
     assert set(users_list) == {"idr8gqdh"}
+
+
+def test_get_offset_dst_summer():
+    # July: America/New_York observes EDT (UTC-4)
+    summer = datetime.datetime(2021, 7, 1, tzinfo=datetime.timezone.utc)
+    ts_ms = int(summer.timestamp() * 1000)
+    assert get_offset(ts_ms, "America/New_York") == -4.0
+
+
+def test_get_offset_dst_winter():
+    # January: America/New_York observes EST (UTC-5)
+    winter = datetime.datetime(2021, 1, 1, tzinfo=datetime.timezone.utc)
+    ts_ms = int(winter.timestamp() * 1000)
+    assert get_offset(ts_ms, "America/New_York") == -5.0
+
+
+def test_get_offset_utc():
+    assert get_offset(1609459200000, "UTC") == 0.0
+
+
+def test_to_timestamp_dst_summer():
+    # 12:00 New York in summer is EDT (UTC-4) -> 16:00 UTC
+    ts = to_timestamp("2021-07-01 12:00:00", "%Y-%m-%d %H:%M:%S",
+                      from_tz=ZoneInfo("America/New_York"))
+    expected = int(
+        datetime.datetime(
+            2021, 7, 1, 16, 0, 0, tzinfo=datetime.timezone.utc
+        ).timestamp() * 1000
+    )
+    assert ts == expected
+
+
+def test_to_timestamp_dst_winter():
+    # 12:00 New York in winter is EST (UTC-5) -> 17:00 UTC
+    ts = to_timestamp("2021-01-01 12:00:00", "%Y-%m-%d %H:%M:%S",
+                      from_tz=ZoneInfo("America/New_York"))
+    expected = int(
+        datetime.datetime(
+            2021, 1, 1, 17, 0, 0, tzinfo=datetime.timezone.utc
+        ).timestamp() * 1000
+    )
+    assert ts == expected
+
+
+def test_to_readable_localizes_to_timezone():
+    # 16:00 UTC -> 12:00 EDT in New York
+    utc_dt = datetime.datetime(
+        2021, 7, 1, 16, 0, 0, tzinfo=datetime.timezone.utc
+    )
+    ts_ms = int(utc_dt.timestamp() * 1000)
+    readable = to_readable(
+        ts_ms, "%Y-%m-%d %H:%M:%S", to_tz="America/New_York"
+    )
+    assert readable == "2021-07-01 12:00:00"


### PR DESCRIPTION
## Summary

Replaces the deprecated `pytz` dependency with the standard-library
`zoneinfo` module (PEP 615) across the `poplar` subpackage. Closes #208.

This was previously blocked on Forest having to stay on Python 3.8
(`zoneinfo` requires 3.9+). Since Forest now targets Python 3.11/3.12
(#288), `zoneinfo` is available natively, so no `backports.zoneinfo`
shim is needed.

## Changes

- Replace `pytz` with `zoneinfo.ZoneInfo` in `poplar/constants/time.py`,
  `poplar/functions/time.py`, `poplar/functions/timezone.py`, and
  `poplar/legacy/common_funcs.py`, plus a docstring in `sycamore/common.py`.
- Replace `tz.localize(dt)` with `dt.replace(tzinfo=ZoneInfo(...))`. Under
  `zoneinfo` this is the correct, DST-aware way to attach a zone — the pytz
  limitation that required `.localize()` does not apply.
- Update type annotations from `pytz.BaseTzInfo` to the stdlib
  `datetime.tzinfo`.
- `pyproject.toml`: drop `pytz` and `types-pytz`; add `tzdata` so timezone
  data is available on systems without a system tz database (pytz had
  bundled its own).

## Tests

Added DST regression tests to `tests/poplar/test_poplar_functions.py` for
`get_offset`, `to_timestamp`, and `to_readable`, which had no prior
coverage. The summer/winter pairs assert that the same wall-clock time maps
to different UTC instants across a DST boundary, confirming the new
localization is DST-aware.

## Verification

- `pytest`: 188 passed (182 existing + 6 new) with `pytz` uninstalled from
  the environment, confirming nothing imports it.
- `flake8` and `mypy src/forest`: clean.

## Note

At the single ambiguous hour of a fall-back DST transition, pytz's
`localize` default and zoneinfo's `fold=0` default resolve the ambiguity
differently. This affects one hour per zone per year, and the prior code
did not specify a preference. Also went with `zoneinfo` per the issue title
(stdlib, no extra dependency) — happy to use `dateutil` instead if preferred,
@biblicabeebli.