### PR TITLE
fix(sycamore): handle empty survey schedule in summarize_submits

### DIFF
--- a/src/forest/sycamore/submits.py
+++ b/src/forest/sycamore/submits.py
@@ -316,7 +316,7 @@ def survey_submits(
                                 all_interventions_dict, history_path)
     if sched.shape[0] == 0:  # return empty dataframe
         logger.error("Error: No survey schedules found")
-        return pd.DataFrame(columns=[["survey id", "beiwe_id"]])
+        return pd.DataFrame(columns=["survey id", "beiwe_id"])
 
     # First, figure out if they opened the survey (if there are any lines
     # related to the survey).
@@ -521,6 +521,20 @@ def summarize_submits(submits_df: pd.DataFrame,
     summary_cols = ["beiwe_id"]
     if summarize_over_survey:
         summary_cols = summary_cols + ["survey id"]
+    # If there is no submit data (e.g. no survey schedule was found upstream),
+    # there is nothing to summarize. Return an empty frame with the columns the
+    # non-empty path would produce, so callers can rely on a consistent shape.
+    if submits.shape[0] == 0 or "delivery_time" not in submits.columns:
+        empty_summary_cols = list(summary_cols)
+        if timeunit in (Frequency.HOURLY_AND_DAILY, Frequency.DAILY,
+                        Frequency.HOURLY):
+            empty_summary_cols = empty_summary_cols + ["year", "month", "day"]
+        if timeunit == Frequency.HOURLY:
+            empty_summary_cols = empty_summary_cols + ["hour"]
+        return pd.DataFrame(columns=empty_summary_cols + [
+            "num_surveys", "num_complete_surveys", "num_opened_surveys",
+            "avg_time_to_submit", "avg_time_to_open", "avg_duration"
+        ])
     submits["delivery_time"] = pd.to_datetime(submits["delivery_time"])
     if timeunit == Frequency.HOURLY_AND_DAILY:
         logger.warning("Error: summarize_submits cannot calculate both daily"

--- a/tests/sycamore/test_functions.py
+++ b/tests/sycamore/test_functions.py
@@ -505,3 +505,18 @@ def test_gen_survey_schedule_with_audio():
         pd.Index(["delivery_time", "next_delivery_time", "id", "beiwe_id",
                   "question_id"])
     ) == 1.0
+
+
+def test_summarize_submits_empty_schedule():
+    """Regression test: summarize_submits must not crash when survey_submits
+    returns an empty frame from the no-schedule branch (issue #319).
+
+    The empty-schedule branch of survey_submits historically returned a
+    DataFrame built with a nested column list, which produced a MultiIndex on
+    the columns and no 'delivery_time' column, crashing summarize_submits with
+    KeyError: 'delivery_time'. An empty frame with flat columns should instead
+    summarize to an empty result.
+    """
+    empty_submits = pd.DataFrame(columns=["survey id", "beiwe_id"])
+    summary = summarize_submits(empty_submits)
+    assert summary.shape[0] == 0


### PR DESCRIPTION
## Summary

Fixes the sycamore crash in #319. When `survey_submits` hits its no-schedule branch, `summarize_submits` raised `KeyError: 'delivery_time'`, matching the production traceback in the issue.

## Root cause

Two issues on the empty-schedule path:

1. The no-schedule branch of `survey_submits` returned `pd.DataFrame(columns=[["survey id", "beiwe_id"]])`. The nested list makes pandas build a **MultiIndex** on the columns (they become `[('survey id',), ('beiwe_id',)]`), which is why the `KeyError` in the issue routes through `multi.py` (`_get_level_indexer` → `_get_loc_single_level_index`).

2. Independently, `summarize_submits` accessed `submits["delivery_time"]` before checking whether the frame was empty, so any empty/`delivery_time`- less input crashed regardless of the column index type.

Reproduced locally:

    import pandas as pd
    df = pd.DataFrame(columns=[["survey id", "beiwe_id"]])
    df["delivery_time"] = pd.to_datetime(df["delivery_time"])  # KeyError

## Changes

- `survey_submits`: flatten the no-schedule return to `columns=["survey id", "beiwe_id"]`.
- `summarize_submits`: early-return an empty frame with the expected output columns when there are no submits (or no `delivery_time` column), so the caller's existing `ss_summary.shape[0] > 0` check behaves correctly.

## Tests

- Added `test_summarize_submits_empty_schedule`, which reproduces the empty-schedule case. It fails on `develop` (KeyError) and passes with this fix.
- Full suite: 183 passed locally; flake8 and `mypy src/forest` clean.