### PR TITLE
feat(poplar): raw-data quality and coverage report

### DIFF
--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -6,6 +6,7 @@ bonsai.md
 jasmine.md
 oak.md
 poplar.md
+quality.md
 poplar-example-code.md
 sycamore.md
 willow.md

--- a/docs/source/quality.md
+++ b/docs/source/quality.md
@@ -1,0 +1,89 @@
+# Data Quality
+
+## Executive Summary:
+Use `poplar.raw.quality` to build a raw-data quality and coverage report
+across every Beiwe data stream. For each participant and stream it
+summarises presence, volume, temporal coverage, ordering and duplication
+issues, unreadable files, and a schema check against the documented
+headers. This sits beside `poplar.raw.doc` (which *describes* streams) and
+`poplar.raw.readers` (which *reads* them): it *validates* them.
+
+Stream knowledge is not hard-coded: the streams and their per-platform
+availability come from `poplar.raw.doc.STREAMS`, and the expected column
+headers from `poplar.raw.doc.HEADERS`, so the report tracks whatever Beiwe
+adds.
+
+## Installation Instruction
+For instructions on how to install forest, please visit
+[here](https://github.com/onnela-lab/forest).
+`from forest.poplar.raw import quality`
+
+## Usage:
+```
+from forest.poplar.raw.quality import run
+from forest.constants import Frequency
+
+
+# Determine study folder and output folder
+study_folder = "project/data"
+output_folder = "project/results"
+
+# Determine study timezone and time frames for data analysis
+tz_str = "America/New_York"
+time_start = "2018-01-01 00_00_00"
+time_end = "2022-01-01 00_00_00"
+
+# Resolution of the coverage metric. Frequency.DAILY gives day coverage,
+# Frequency.HOURLY hour coverage, etc. Frequency.HOURLY_AND_DAILY is treated
+# as daily. See forest.constants.Frequency:
+# https://github.com/onnela-lab/forest/blob/develop/forest/constants.py
+frequency = Frequency.DAILY
+users = None
+
+run(study_folder, output_folder, tz_str, frequency,
+    time_start, time_end, users)
+```
+
+## Coverage and schema
+
+Coverage is the fraction of `frequency`-sized bins that contain at least one
+observation, over the span from the first to the last observation. Every
+stream shares a `timestamp` column (milliseconds since the Unix epoch, UTC),
+which is used for all temporal metrics; timestamps are localised to `tz_str`
+before day/hour binning.
+
+The schema check compares each stream's actual columns to the documented
+header for the participant's device OS (read from the `identifiers` stream).
+It reports one of four states: `ok`, `mismatch` (with the missing and extra
+columns listed), `undocumented` (the header is not yet documented), or `na`
+(no documented header for that stream/OS).
+
+## List of summary statistics
+
+The output is written to `data_quality.csv` with one row per participant per
+data stream. The following variables are created:
+
+| Variable | Type | Description of Variable |
+|---|---|---|
+| backend_id | str | Beiwe backend identifier of the participant |
+| device_os | str | Device OS from the identifiers stream (Android, iOS, or unknown) |
+| stream | str | Name of the data stream |
+| stream_type | str | passive or survey |
+| expected | bool | Whether the stream is available for the participant's OS |
+| present | bool | Whether the stream folder exists with at least one CSV |
+| n_files | int | Number of CSV files in the stream folder |
+| size_mb | float | Total size of the stream folder, in megabytes |
+| n_rows | int | Total number of rows across all files |
+| first_observation | str | Earliest observation, local time (ISO 8601) |
+| last_observation | str | Latest observation, local time (ISO 8601) |
+| n_days_spanned | int | Number of calendar days from first to last observation |
+| days_with_data | int | Number of distinct local dates with at least one observation |
+| coverage | float | Fraction of frequency-sized bins containing data |
+| resolution | str | Name of the coverage resolution (e.g. DAILY) |
+| largest_gap_h | float | Largest gap between consecutive observations, in hours |
+| n_duplicate_rows | int | Number of exactly duplicated rows |
+| n_out_of_order | int | Number of rows whose timestamp is earlier than the previous row |
+| n_unreadable_files | int | Number of CSV files that could not be read |
+| schema_status | str | ok, mismatch, undocumented, or na |
+| missing_columns | str | Documented columns absent from the data (semicolon-separated) |
+| extra_columns | str | Columns present in the data but not documented (semicolon-separated) |

--- a/src/forest/poplar/raw/quality.py
+++ b/src/forest/poplar/raw/quality.py
@@ -101,7 +101,10 @@ def _device_os(study_folder: str, backend_id: str) -> str:
     id_dir = os.path.join(study_folder, backend_id, IDENTIFIERS_STREAM)
     if not os.path.isdir(id_dir):
         return "unknown"
-    files = sorted(f for f in os.listdir(id_dir) if f.endswith(".csv"))
+    files = sorted(
+        f for f in os.listdir(id_dir)
+        if f.endswith((".csv", ".csv.zst"))
+    )
     device_os = "unknown"
     for name in files:
         try:
@@ -279,7 +282,7 @@ def _stream_row(
     if not os.path.isdir(stream_dir):
         return row
     files = sorted(f for f in os.listdir(stream_dir)
-                   if f.endswith(".csv"))
+                   if f.endswith((".csv", ".csv.zst")))
     if not files:
         return row
     row["present"] = True

--- a/src/forest/poplar/raw/quality.py
+++ b/src/forest/poplar/raw/quality.py
@@ -1,0 +1,375 @@
+"""Raw-data quality and coverage report for Beiwe study folders.
+
+Sits alongside ``poplar.raw.doc`` (which *describes* raw streams) and
+``poplar.raw.readers`` (which *reads* them): this module *validates* them.
+For every participant and every data stream it summarises presence, volume,
+temporal coverage, ordering/duplication issues, unreadable files, and a
+schema check against the documented headers.
+
+Stream knowledge is not hard-coded. The list of streams and their
+per-platform availability comes from ``poplar.raw.doc.STREAMS``; expected
+column headers come from ``poplar.raw.doc.HEADERS``. The report therefore
+tracks whatever Beiwe adds and never drifts from the packaged documentation.
+
+The public entry point ``run`` writes a single long-format
+``data_quality.csv`` with one row per ``(backend_id, stream)``.
+
+Note: this is a coverage/quality inventory, not statistical anomaly
+detection on the signal values -- that is a natural follow-on.
+"""
+from __future__ import annotations
+
+import logging
+import os
+
+import numpy as np
+import pandas as pd
+
+from forest.constants import Frequency
+from forest.poplar.raw.doc import HEADERS, STREAMS
+from forest.utils import get_ids
+
+logger = logging.getLogger(__name__)
+
+IDENTIFIERS_STREAM = "identifiers"
+MS_PER_HOUR = 3_600_000
+NS_PER_MINUTE = 60_000_000_000
+
+# Column order for the output report.
+REPORT_COLUMNS = [
+    "backend_id", "device_os", "stream", "stream_type", "expected",
+    "present", "n_files", "size_mb", "n_rows", "first_observation",
+    "last_observation", "n_days_spanned", "days_with_data", "coverage",
+    "resolution", "largest_gap_h", "n_duplicate_rows", "n_out_of_order",
+    "n_unreadable_files", "schema_status", "missing_columns",
+    "extra_columns",
+]
+
+_READ_ERRORS = (
+    pd.errors.EmptyDataError, pd.errors.ParserError, ValueError, OSError,
+)
+
+
+def _bin_minutes(frequency: Frequency) -> int:
+    """Coverage bin size in minutes; the two-resolution sentinel is daily."""
+    if frequency == Frequency.HOURLY_AND_DAILY:
+        return int(Frequency.DAILY.value)
+    return int(frequency.value)
+
+
+def _resolution_label(frequency: Frequency) -> str:
+    """Human-readable name of the coverage resolution."""
+    if frequency == Frequency.HOURLY_AND_DAILY:
+        return "DAILY"
+    return frequency.name
+
+
+def _dir_size_mb(stream_dir: str, ndigits: int = 2) -> float:
+    """Total size in megabytes of the files directly in ``stream_dir``."""
+    total = 0
+    for name in os.listdir(stream_dir):
+        path = os.path.join(stream_dir, name)
+        if os.path.isfile(path):
+            total += os.path.getsize(path)
+    return round(total / (2 ** 20), ndigits)
+
+
+def _read_concat(stream_dir: str, files: list) -> tuple:
+    """Concatenate readable CSVs, counting unreadable ones.
+
+    Returns ``(data_frame_or_none, n_unreadable)``.
+    """
+    frames = []
+    n_unreadable = 0
+    for name in files:
+        try:
+            frames.append(pd.read_csv(os.path.join(stream_dir, name)))
+        except _READ_ERRORS:
+            n_unreadable += 1
+            logger.warning("unreadable file %s", name)
+    if not frames:
+        return None, n_unreadable
+    return pd.concat(frames, ignore_index=True), n_unreadable
+
+
+def _device_os(study_folder: str, backend_id: str) -> str:
+    """Read the identifiers stream for the participant's OS.
+
+    Returns ``"Android"``, ``"iOS"`` or ``"unknown"``. If the participant
+    re-enrolled, the most recent identifiers row wins.
+    """
+    id_dir = os.path.join(study_folder, backend_id, IDENTIFIERS_STREAM)
+    if not os.path.isdir(id_dir):
+        return "unknown"
+    files = sorted(f for f in os.listdir(id_dir) if f.endswith(".csv"))
+    device_os = "unknown"
+    for name in files:
+        try:
+            frame = pd.read_csv(os.path.join(id_dir, name))
+        except _READ_ERRORS:
+            continue
+        columns = {c.strip().lower(): c for c in frame.columns}
+        if "device_os" in columns and len(frame):
+            value = str(frame[columns["device_os"]].iloc[-1]).strip()
+            if value:
+                device_os = value
+    return device_os
+
+
+def _is_expected(stream: str, device_os: str) -> bool:
+    """Whether ``stream`` should exist given the participant's OS."""
+    info = STREAMS.get(stream)
+    if info is None:
+        return False
+    if device_os in ("Android", "iOS"):
+        return bool(info[device_os])
+    return bool(info["Android"] or info["iOS"])
+
+
+def _expected_columns(stream: str, device_os: str):
+    """Documented header for ``stream``: a column list, ``"To do"``, or None.
+
+    When the OS is unknown, prefer a documented list from either platform.
+    """
+    entry = HEADERS.get(stream) if HEADERS is not None else None
+    if entry is None:
+        return None
+    if device_os in ("Android", "iOS"):
+        return entry.get(device_os)
+    for candidate in (entry.get("iOS"), entry.get("Android")):
+        if isinstance(candidate, list):
+            return candidate
+    return entry.get("iOS") if entry.get("iOS") is not None \
+        else entry.get("Android")
+
+
+def _schema_check(actual: list, expected) -> tuple:
+    """Compare actual columns to the documented header.
+
+    Returns ``(status, missing_columns, extra_columns)`` where status is
+    ``"ok"``, ``"mismatch"``, ``"undocumented"`` (header is ``"To do"``) or
+    ``"na"`` (no documented header).
+    """
+    if isinstance(expected, list):
+        missing = [c for c in expected if c not in actual]
+        extra = [c for c in actual if c not in expected]
+        status = "ok" if not missing and not extra else "mismatch"
+        return status, missing, extra
+    if expected == "To do":
+        return "undocumented", [], []
+    return "na", [], []
+
+
+def _parse_bound(value: str | None, tz_str: str) -> int | None:
+    """Parse a ``%Y-%m-%d %H_%M_%S`` bound into a UTC millisecond stamp."""
+    if value is None:
+        return None
+    naive = pd.to_datetime(value, format="%Y-%m-%d %H_%M_%S")
+    localized = pd.Timestamp(naive).tz_localize(tz_str)
+    return int(localized.value // 1_000_000)
+
+
+def _apply_time_filter(
+    data_frame: pd.DataFrame, tz_str: str,
+    time_start: str | None, time_end: str | None,
+) -> pd.DataFrame:
+    """Restrict rows to the ``[time_start, time_end]`` window if given."""
+    columns = {c.strip().lower(): c for c in data_frame.columns}
+    if "timestamp" not in columns:
+        return data_frame
+    lower = _parse_bound(time_start, tz_str)
+    upper = _parse_bound(time_end, tz_str)
+    if lower is None and upper is None:
+        return data_frame
+    stamps = pd.to_numeric(data_frame[columns["timestamp"]],
+                           errors="coerce")
+    mask = pd.Series(True, index=data_frame.index)
+    if lower is not None:
+        mask &= stamps >= lower
+    if upper is not None:
+        mask &= stamps <= upper
+    return data_frame[mask]
+
+
+def _quality_metrics(
+    data_frame: pd.DataFrame, tz_str: str, bin_minutes: int
+) -> dict:
+    """Row-level quality and coverage metrics keyed off ``timestamp``."""
+    columns = {c.strip().lower(): c for c in data_frame.columns}
+    n_rows = int(len(data_frame))
+    metrics = {
+        "n_rows": n_rows,
+        "n_duplicate_rows": int(n_rows - len(data_frame.drop_duplicates())),
+        "n_out_of_order": 0,
+        "first_observation": "",
+        "last_observation": "",
+        "n_days_spanned": 0,
+        "days_with_data": 0,
+        "coverage": float("nan"),
+        "largest_gap_h": float("nan"),
+    }
+    if "timestamp" not in columns:
+        return metrics
+    stamps = pd.to_numeric(data_frame[columns["timestamp"]],
+                           errors="coerce").dropna()
+    values = stamps.astype("int64").to_numpy()
+    if values.size == 0:
+        return metrics
+    metrics["n_out_of_order"] = int(np.sum(np.diff(values) < 0))
+    ordered = np.sort(values)
+    if ordered.size > 1:
+        metrics["largest_gap_h"] = round(
+            int(np.max(np.diff(ordered))) / MS_PER_HOUR, 3
+        )
+    local = (
+        pd.to_datetime(ordered, unit="ms", utc=True)
+        .tz_convert(tz_str).tz_localize(None)
+    )
+    metrics["first_observation"] = local.min().isoformat()
+    metrics["last_observation"] = local.max().isoformat()
+    metrics["days_with_data"] = int(pd.Index(local.date).nunique())
+    span = (local.max().normalize() - local.min().normalize()).days + 1
+    metrics["n_days_spanned"] = int(span)
+    bins = local.astype("int64") // (bin_minutes * NS_PER_MINUTE)
+    observed = int(np.unique(bins).size)
+    expected = int(bins.max() - bins.min()) + 1
+    if expected > 0:
+        metrics["coverage"] = round(observed / expected, 4)
+    return metrics
+
+
+def _blank_row(
+    backend_id: str, device_os: str, stream: str, frequency: Frequency
+) -> dict:
+    """A report row for an absent or empty stream."""
+    return {
+        "backend_id": backend_id,
+        "device_os": device_os,
+        "stream": stream,
+        "stream_type": STREAMS.get(stream, {}).get("type", ""),
+        "expected": _is_expected(stream, device_os),
+        "present": False,
+        "n_files": 0,
+        "size_mb": 0.0,
+        "n_rows": 0,
+        "first_observation": "",
+        "last_observation": "",
+        "n_days_spanned": 0,
+        "days_with_data": 0,
+        "coverage": float("nan"),
+        "resolution": _resolution_label(frequency),
+        "largest_gap_h": float("nan"),
+        "n_duplicate_rows": 0,
+        "n_out_of_order": 0,
+        "n_unreadable_files": 0,
+        "schema_status": "na",
+        "missing_columns": "",
+        "extra_columns": "",
+    }
+
+
+def _stream_row(
+    study_folder: str, backend_id: str, device_os: str, stream: str,
+    frequency: Frequency, tz_str: str,
+    time_start: str | None, time_end: str | None,
+) -> dict:
+    """Build the full report row for one participant-stream pair."""
+    row = _blank_row(backend_id, device_os, stream, frequency)
+    stream_dir = os.path.join(study_folder, backend_id, stream)
+    if not os.path.isdir(stream_dir):
+        return row
+    files = sorted(f for f in os.listdir(stream_dir)
+                   if f.endswith(".csv"))
+    if not files:
+        return row
+    row["present"] = True
+    row["n_files"] = len(files)
+    row["size_mb"] = _dir_size_mb(stream_dir)
+    data_frame, n_unreadable = _read_concat(stream_dir, files)
+    row["n_unreadable_files"] = n_unreadable
+    if data_frame is None or data_frame.empty:
+        return row
+    data_frame = _apply_time_filter(
+        data_frame, tz_str, time_start, time_end
+    )
+    if data_frame.empty:
+        return row
+    row.update(
+        _quality_metrics(data_frame, tz_str, _bin_minutes(frequency))
+    )
+    status, missing, extra = _schema_check(
+        list(data_frame.columns), _expected_columns(stream, device_os)
+    )
+    row["schema_status"] = status
+    row["missing_columns"] = ";".join(missing)
+    row["extra_columns"] = ";".join(extra)
+    return row
+
+
+def _streams_to_report(
+    study_folder: str, backend_id: str, device_os: str
+) -> list:
+    """Union of streams expected for the OS and streams found on disk."""
+    if device_os in ("Android", "iOS"):
+        expected = {s for s, v in STREAMS.items() if v[device_os]}
+    else:
+        expected = {
+            s for s, v in STREAMS.items() if v["Android"] or v["iOS"]
+        }
+    found: set = set()
+    participant_dir = os.path.join(study_folder, backend_id)
+    if os.path.isdir(participant_dir):
+        found = {
+            name for name in os.listdir(participant_dir)
+            if name in STREAMS
+            and os.path.isdir(os.path.join(participant_dir, name))
+        }
+    return sorted(expected | found)
+
+
+def run(
+    study_folder: str,
+    output_folder: str,
+    tz_str: str,
+    frequency: Frequency = Frequency.DAILY,
+    time_start: str | None = None,
+    time_end: str | None = None,
+    users: list | None = None,
+) -> pd.DataFrame:
+    """Build a raw-data quality report for a Beiwe study folder.
+
+    Args:
+        study_folder: Path with one subfolder per backend ID, each holding
+            one subfolder per data stream of raw CSVs.
+        output_folder: Directory for ``data_quality.csv`` (created if
+            absent).
+        tz_str: IANA timezone of the study site.
+        frequency: Resolution of the coverage metric; ``Frequency.DAILY``
+            gives day coverage, ``Frequency.HOURLY`` hour coverage, and so
+            on. ``Frequency.HOURLY_AND_DAILY`` is treated as daily.
+        time_start: Optional lower bound, ``%Y-%m-%d %H_%M_%S``.
+        time_end: Optional upper bound, ``%Y-%m-%d %H_%M_%S``.
+        users: Optional explicit backend IDs; otherwise all are used.
+
+    Returns:
+        The report DataFrame (also written to disk), one row per
+        ``(backend_id, stream)``.
+    """
+    os.makedirs(output_folder, exist_ok=True)
+    if users is None:
+        users = get_ids(study_folder)
+    rows = []
+    for backend_id in users:
+        device_os = _device_os(study_folder, backend_id)
+        for stream in _streams_to_report(
+            study_folder, backend_id, device_os
+        ):
+            rows.append(_stream_row(
+                study_folder, backend_id, device_os, stream,
+                frequency, tz_str, time_start, time_end,
+            ))
+    report = pd.DataFrame(rows, columns=REPORT_COLUMNS)
+    report.to_csv(
+        os.path.join(output_folder, "data_quality.csv"), index=False
+    )
+    return report

--- a/tests/poplar/test_quality.py
+++ b/tests/poplar/test_quality.py
@@ -122,3 +122,45 @@ def test_bin_minutes():
     assert _bin_minutes(Frequency.DAILY) == 1440
     assert _bin_minutes(Frequency.HOURLY) == 60
     assert _bin_minutes(Frequency.HOURLY_AND_DAILY) == 1440
+
+
+def test_run_discovers_zst_files(tmp_path):
+    """Compressed .csv.zst streams must be discovered and read, matching
+    the sycamore fix in #320. Without the extension fix, discovery filters
+    to .csv only and the stream is reported absent."""
+    root = tmp_path / "study"
+    pid = "participantZ"
+
+    _write(
+        root / pid / "identifiers" / "2026-03-01 00_00_00.csv",
+        pd.DataFrame({
+            "timestamp": [_ms("2026-03-01T00:00:00Z")],
+            "UTC time": ["2026-03-01T00:00:00.000"],
+            "patient_id": [pid],
+            "device_os": ["Android"],
+        }),
+    )
+
+    base = pd.Timestamp("2026-03-01T00:00:00Z")
+    stamps = [base + pd.Timedelta(hours=h) for h in range(24)]
+    frame = pd.DataFrame({
+        "timestamp": [_ms(t) for t in stamps],
+        "UTC time": [t.isoformat() for t in stamps],
+        "accuracy": ["unknown"] * 24,
+        "x": np.zeros(24),
+        "y": np.zeros(24),
+        "z": np.ones(24),
+    })
+    # Write the accelerometer stream as a single compressed .csv.zst file.
+    acc_dir = root / pid / "accelerometer"
+    acc_dir.mkdir(parents=True, exist_ok=True)
+    frame.to_csv(acc_dir / "2026-03-01 00_00_00.csv.zst", index=False)
+
+    out = tmp_path / "out"
+    report = run(str(root), str(out), TZ, frequency=Frequency.DAILY)
+
+    acc = report[report["stream"] == "accelerometer"].iloc[0]
+    assert acc["present"]
+    assert acc["n_files"] == 1
+    assert acc["n_rows"] == 24
+    assert acc["n_unreadable_files"] == 0

--- a/tests/poplar/test_quality.py
+++ b/tests/poplar/test_quality.py
@@ -1,0 +1,124 @@
+"""Tests for forest.poplar.raw.quality (raw-data quality report).
+
+Builds a synthetic study folder that deliberately contains a clean stream,
+a stream with a schema mismatch plus a gap, duplicate and out-of-order
+rows plus an unreadable file, and an expected-but-absent stream.
+"""
+import numpy as np
+import pandas as pd
+import pytest
+
+from forest.constants import Frequency
+from forest.poplar.raw.quality import (
+    REPORT_COLUMNS,
+    _bin_minutes,
+    _schema_check,
+    run,
+)
+
+TZ = "America/New_York"
+
+
+def _ms(timestamp):
+    return int(pd.Timestamp(timestamp).value // 1_000_000)
+
+
+def _write(path, frame):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    frame.to_csv(path, index=False)
+
+
+@pytest.fixture
+def study(tmp_path):
+    root = tmp_path / "study"
+    pid = "participantA"
+
+    _write(
+        root / pid / "identifiers" / "2026-03-01 00_00_00.csv",
+        pd.DataFrame({
+            "timestamp": [_ms("2026-03-01T00:00:00Z")],
+            "UTC time": ["2026-03-01T00:00:00.000"],
+            "patient_id": [pid],
+            "device_os": ["iOS"],
+        }),
+    )
+
+    for day in ("2026-03-01", "2026-03-02"):
+        base = pd.Timestamp(day + "T00:00:00Z")
+        stamps = [base + pd.Timedelta(hours=h) for h in range(24)]
+        _write(
+            root / pid / "accelerometer" / f"{day} 00_00_00.csv",
+            pd.DataFrame({
+                "timestamp": [_ms(t) for t in stamps],
+                "UTC time": [t.isoformat() for t in stamps],
+                "accuracy": ["unknown"] * 24,
+                "x": np.zeros(24),
+                "y": np.zeros(24),
+                "z": np.ones(24),
+            }),
+        )
+
+    rows = []
+    day0 = pd.Timestamp("2026-03-01T00:00:00Z")
+    for h in range(24):
+        t = day0 + pd.Timedelta(hours=h)
+        rows.append([_ms(t), t.isoformat(), 43.0 + 0.001 * h, -74.0, 12.0])
+    day3 = pd.Timestamp("2026-03-04T00:00:00Z")  # two-day gap
+    for h in range(24):
+        t = day3 + pd.Timedelta(hours=h)
+        rows.append([_ms(t), t.isoformat(), 43.5, -74.1, 15.0])
+    rows.append(list(rows[0]))  # exact duplicate
+    early = day0 + pd.Timedelta(hours=5)
+    rows.append([_ms(early), early.isoformat(), 43.9, -74.2, 20.0])  # OOO
+    gps = pd.DataFrame(
+        rows,
+        columns=["timestamp", "UTC time", "latitude", "longitude",
+                 "accuracy"],  # 'altitude' deliberately missing
+    )
+    _write(root / pid / "gps" / "2026-03-01 00_00_00.csv", gps)
+    (root / pid / "gps" / "empty.csv").write_text("")  # unreadable
+
+    return root
+
+
+def test_run_report(study, tmp_path):
+    out = tmp_path / "out"
+    report = run(str(study), str(out), TZ, frequency=Frequency.DAILY)
+
+    assert (out / "data_quality.csv").exists()
+    assert list(report.columns) == REPORT_COLUMNS
+    assert (report["device_os"] == "iOS").all()
+
+    acc = report[report["stream"] == "accelerometer"].iloc[0]
+    assert acc["present"]
+    assert acc["expected"]
+    assert acc["schema_status"] == "ok"
+    assert acc["n_rows"] == 48
+    assert acc["n_unreadable_files"] == 0
+    assert acc["coverage"] == 1.0
+
+    gps = report[report["stream"] == "gps"].iloc[0]
+    assert gps["schema_status"] == "mismatch"
+    assert "altitude" in gps["missing_columns"]
+    assert gps["n_duplicate_rows"] >= 1
+    assert gps["n_out_of_order"] >= 1
+    assert gps["largest_gap_h"] > 24
+    assert gps["n_unreadable_files"] >= 1
+
+    power = report[report["stream"] == "power_state"].iloc[0]
+    assert power["expected"]
+    assert not power["present"]
+
+
+def test_schema_check_states():
+    assert _schema_check(["a", "b"], ["a", "b", "c"]) == (
+        "mismatch", ["c"], [])
+    assert _schema_check(["a", "b"], ["a", "b"]) == ("ok", [], [])
+    assert _schema_check(["a"], "To do") == ("undocumented", [], [])
+    assert _schema_check(["a"], None) == ("na", [], [])
+
+
+def test_bin_minutes():
+    assert _bin_minutes(Frequency.DAILY) == 1440
+    assert _bin_minutes(Frequency.HOURLY) == 60
+    assert _bin_minutes(Frequency.HOURLY_AND_DAILY) == 1440


### PR DESCRIPTION
Adds `poplar/raw/quality.py`: a cross-stream raw-data quality and coverage report for a study folder sitting beside `poplar.raw.doc` (which *describes* streams) and `poplar.raw.readers` (which *reads* them), as the *validation* piece.

Per participant × stream it reports presence vs. expected-for-OS, file count and size, row count, first/last observation, days spanned and coverage, largest gap, duplicate and out-of-order rows, unreadable files, and a schema check against the documented header. `run()` writes one long format `data_quality.csv`, one row per `(backend_id, stream)`.

Design
- Stream knowledge isn't hard-coded: reads `STREAMS` (per-OS availability) and `HEADERS` (expected columns) from `poplar.raw.doc`, so it tracks whatever Beiwe adds. Schema check is three-state to match `HEADERS`: validate a column list, `undocumented` for `"To do"`, `na` for `null`.
- Device OS is read from the `identifiers` stream (headers differ by OS, e.g. power_state).
- `run(study_folder, output_folder, tz_str, frequency, time_start, time_end, users)` mirrors the other trees; `frequency` sets the coverage-bin resolution (`HOURLY_AND_DAILY` treated as daily).
- numpy/pandas only; deliberately does not reuse `clean_dataframe` (dedups in place, which would erase the duplicates I need to count) or `read_data` (GPS/accel-specific, returns filenames for accel).

Notes / open questions
- Coverage-via-`frequency`, or would you prefer fixed hour + day columns?
- Placement `poplar/raw/quality.py` reasonable, or elsewhere?

Tests: `tests/poplar/test_quality.py` defect-injection (clean stream; a stream with schema mismatch + gap + duplicate + out-of-order + unreadable file; an expected-but-absent stream) + end-to-end. ruff/flake8/mypy clean; full suite green.
Docs: `docs/source/quality.md` (+ toctree).