### PR TITLE
fix(sycamore): reference correct output_dir arg in CLI guard

### DIFF
--- a/src/forest/sycamore/__main__.py
+++ b/src/forest/sycamore/__main__.py
@@ -39,7 +39,7 @@ parser.add_argument(
 
 args = parser.parse_args()
 
-if args.study_folder is None or args.output_folder is None:
+if args.study_folder is None or args.output_dir is None:
     parser.print_help()
     sys.exit()
 

--- a/tests/sycamore/test_functions.py
+++ b/tests/sycamore/test_functions.py
@@ -1,4 +1,6 @@
 import os
+import subprocess
+import sys
 
 import numpy as np
 import pandas as pd
@@ -505,3 +507,21 @@ def test_gen_survey_schedule_with_audio():
         pd.Index(["delivery_time", "next_delivery_time", "id", "beiwe_id",
                   "question_id"])
     ) == 1.0
+
+
+def test_sycamore_cli_missing_output_dir_prints_help(tmp_path):
+    """Regression test: running the sycamore CLI with --study_folder but no
+    --output_dir should print help and exit cleanly, not raise AttributeError.
+
+    The missing-argument guard previously referenced args.output_folder while
+    the argument is --output_dir, so this path raised
+    AttributeError: 'Namespace' object has no attribute 'output_folder'.
+    """
+    result = subprocess.run(
+        [sys.executable, "-m", "forest.sycamore",
+         "--study_folder", str(tmp_path)],
+        capture_output=True, text=True
+    )
+    assert result.returncode == 0
+    assert "usage:" in result.stdout
+    assert "AttributeError" not in result.stderr


### PR DESCRIPTION
Running `python -m forest.sycamore --study_folder ...` without an output dir raised `AttributeError: 'Namespace' object has no attribute 'output_folder'`  the missing-argument guard checked `args.output_folder`, but the CLI argument is `--output_dir`. Fixes the guard to check `args.output_dir` so it prints help and exits cleanly, and adds a subprocess regression test.

ruff/flake8/mypy clean; full suite green.